### PR TITLE
junit: fix log message about used files

### DIFF
--- a/junit.go
+++ b/junit.go
@@ -47,7 +47,7 @@ func getFileTimesFromJUnitXML(fileTimes map[string]float64) {
 			if err != nil {
 				fatalMsg("failed to open junit xml: %v\n", err)
 			}
-			printMsg("using test times from JUnit report %s\n", junitXMLPath)
+			printMsg("using test times from JUnit report %s\n", junitFilename)
 			addFileTimesFromIOReader(fileTimes, file)
 			file.Close()
 		}


### PR DESCRIPTION
Currently the log message always print the glob pattern. For instance:

> using test times from JUnit report tmp/*.junit.xml
> using test times from JUnit report tmp/*.junit.xml

Instead the actual file name should be used:

> using test times from JUnit report tmp/report_0.junit.xml
> using test times from JUnit report tmp/report_1.junit.xml