### PR TITLE
Build for ARM64 Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,19 @@
-release: release-linux release-osx
+release: release-linux release-osx release-linux-arm
 
 release-linux:
-	$(call release-base,linux)
+	$(call release-base,linux,amd64)
 
 release-osx:
-	$(call release-base,darwin)
+	$(call release-base,darwin,amd64)
+
+release-linux-arm:
+	$(call release-base,linux,arm64)
 
 
 release-base = \
 	mkdir -p build; \
-	GOOS=$(1) GOARCH=amd64 go build -ldflags="-s -w" -o build/split_tests; \
-	gzip -S .$(1).gz build/split_tests
+	GOOS=$(1) GOARCH=$(2) go build -ldflags="-s -w" -o build/split_tests; \
+	gzip -S .$(1)$(if $(filter arm64,$(2)),.$(2)).gz build/split_tests
 
 clean:
 	rm -rf build


### PR DESCRIPTION
## Synopsis

As well as the existing build files:

* `build/split_tests.darwin.gz`
* `build/split_tests.linux.gz`

the following new build file will be created.

* `build/split_tests.linux.arm64.gz`

> [!NOTE]
>
> The names of the existing build files are not modified; this is to prevent breaking client code (e.g. GitHub Marketplace Actions) that depend on the existing file names for build artefacts.